### PR TITLE
feat: add bypass option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ app.listen(3000)
 - `provider`
 - `providerOptions`
 - `sessionSecret`
-- `enabled` (default: `true`)
+- `bypass`
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ app.listen(3000)
 - `provider`
 - `providerOptions`
 - `sessionSecret`
+- `enabled` (default: `true`)
 
 ## Providers
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export function createAuth (opts: CreateAuthOptions) {
 }
 
 export function createAuthMiddleware (opts: CreateAuthOptions) {
-  if (!opts.enabled) {
+  if (opts.enabled === false) {
     return (_req, _res, next) => next()
   }
   const auth = createAuth(opts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export interface CreateAuthOptions {
   sessionSecret?: string
   provider?: string
   providerOptions?: any
-  enabled: boolean
+  bypass: boolean
 }
 
 const noop = () => { }
@@ -22,7 +22,7 @@ export function createAuth (opts: CreateAuthOptions) {
 }
 
 export function createAuthMiddleware (opts: CreateAuthOptions) {
-  if (opts.enabled === false) {
+  if (opts.bypass === true) {
     return (_req, _res, next = noop) => next()
   }
   const auth = createAuth(opts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export interface CreateAuthOptions {
   sessionSecret?: string
   provider?: string
   providerOptions?: any
+  enabled: boolean
 }
 
 const noop = () => { }
@@ -21,12 +22,22 @@ export function createAuth (opts: CreateAuthOptions) {
 }
 
 export function createAuthMiddleware (opts: CreateAuthOptions) {
+  if (!opts.enabled) {
+    return (_req, _res, next) => next()
+  }
   const auth = createAuth(opts)
 
   return async (req, res, next = noop) => {
     // Load Session
     const sessionStr = cookie.parse(req.headers.cookie || '').session
-    const session = sessionStr ? jwt.verify(sessionStr, opts.sessionSecret) : {}
+    let session = {}
+    if (sessionStr) {
+      try {
+        session = jwt.verify(sessionStr, opts.sessionSecret)
+      } catch (err) {
+        // Ignore error and re-validate the session
+      }
+    }
 
     // Populate req.auth
     req.auth = { session }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export function createAuth (opts: CreateAuthOptions) {
 
 export function createAuthMiddleware (opts: CreateAuthOptions) {
   if (opts.enabled === false) {
-    return (_req, _res, next) => next()
+    return (_req, _res, next = noop) => next()
   }
   const auth = createAuth(opts)
 

--- a/test/bypass.ts
+++ b/test/bypass.ts
@@ -5,7 +5,7 @@ import { createAuthMiddleware } from '../src'
 const app = createApp()
 
 app.useAsync(createAuthMiddleware({
-  enabled: false,
+  bypass: true,
   provider: 'basic',
   providerOptions: {
     username: 'test',

--- a/test/enabled.ts
+++ b/test/enabled.ts
@@ -1,0 +1,18 @@
+import { createApp } from 'h3'
+import { listen } from 'listhen'
+import { createAuthMiddleware } from '../src'
+
+const app = createApp()
+
+app.useAsync(createAuthMiddleware({
+  enabled: false,
+  provider: 'basic',
+  providerOptions: {
+    username: 'test',
+    password: 'test'
+  }
+}))
+
+app.useAsync(req => `Welcome ${req.auth}!`)
+
+listen(app)


### PR DESCRIPTION
- Add `enabled` option to disable it in dev mode for example (cleaner to read than a ternary inside `serverMiddleware`)
- Added a try/catch around `jwt.verify` to avoid throwing an error if the sessionSecret has changed, instead we revalidate the session